### PR TITLE
Fix parsing of PIDs

### DIFF
--- a/postfix-log-parser.go
+++ b/postfix-log-parser.go
@@ -12,7 +12,7 @@ const (
 	TimeFormatISO8601          = "2006-01-02T15:04:05.999999-07:00"
 	TimeRegexpFormat           = `([A-Za-z]{3}\s*[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2}|^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:[+-][0-2]\d:[0-5]\d|Z))`
 	HostRegexpFormat           = `([0-9A-Za-z\-\.]*)`
-	ProcessRegexpFormat        = `(postfix.*(?:\/[a-z]*)+\[[0-9]{1,5}\])?`
+	ProcessRegexpFormat        = `(postfix.*(?:\/[a-z]*)+\[[0-9]{1,7}\])?`
 	QueueIdRegexpFormat        = `([0-9A-Z]*)`
 	ClientRegexpFormat         = `(?:client=(.+)\[(.+)\](?:, sasl_method=(.+), sasl_username=(.+))?)?`
 	MessageIdRegexpFormat      = `(?:message-id=<(.+)>)?`


### PR DESCRIPTION
On Linux 64bit systems, PIDs can go up to 2^22 (7 digits).